### PR TITLE
调查个人资料页登出问题

### DIFF
--- a/backend/src/main/java/com/forum/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/forum/config/JwtAuthenticationFilter.java
@@ -104,6 +104,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return path.startsWith("/api/auth/login") || 
                path.startsWith("/api/auth/register") ||
                (path.startsWith("/api/") && "GET".equals(request.getMethod()) && 
-                (path.contains("/posts") || path.contains("/categories") || path.contains("/comments") || path.contains("/users")));
+                (path.contains("/posts") || path.contains("/categories") || path.contains("/comments")) &&
+                !path.contains("/me")) || // 排除包含 /me 的个人接口
+               // 允许访问其他用户的公开信息（非 /me 接口）
+               (path.startsWith("/api/users/") && "GET".equals(request.getMethod()) && 
+                !path.contains("/me") && (path.matches(".*/users/[^/]+/?$") || path.matches(".*/users/[^/]+/stats$")));
     }
 } 

--- a/backend/src/main/java/com/forum/config/SecurityConfig.java
+++ b/backend/src/main/java/com/forum/config/SecurityConfig.java
@@ -64,10 +64,12 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/posts/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/categories/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/comments/**").permitAll()
-                .requestMatchers(HttpMethod.GET, "/users/**").permitAll()
+                // 允许访问其他用户的公开信息，但不包括 /me 接口
+                .requestMatchers(HttpMethod.GET, "/users/{username}", "/users/{username}/stats").permitAll()
                 
                 // 需要认证的端点
                 .requestMatchers("/auth/me").authenticated()
+                .requestMatchers("/users/me/**").authenticated() // 个人信息相关接口需要认证
                 
                 // 帖子相关权限
                 .requestMatchers(HttpMethod.POST, "/posts/**").authenticated()

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -22,9 +22,26 @@
               <el-menu-item index="2">
                 <router-link to="/posts">帖子</router-link>
               </el-menu-item>
-              <el-menu-item index="3">
-                <router-link to="/categories">分类</router-link>
-              </el-menu-item>
+              <el-sub-menu index="3">
+                <template #title>分类</template>
+                <el-menu-item index="3-0">
+                  <router-link to="/categories">所有分类</router-link>
+                </el-menu-item>
+                <template v-if="categories.length > 0">
+                  <el-menu-item 
+                    v-for="category in categories.slice(0, 8)" 
+                    :key="category.id" 
+                    :index="`3-${category.id}`"
+                  >
+                    <router-link :to="`/categories/${category.id}`">
+                      {{ category.name }}
+                    </router-link>
+                  </el-menu-item>
+                </template>
+                <el-menu-item v-else index="3-loading">
+                  <span style="color: #999;">加载中...</span>
+                </el-menu-item>
+              </el-sub-menu>
             </el-menu>
           </div>
           
@@ -83,6 +100,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { categoryAPI } from '@/api/categories'
 import { House, Plus, User, Document, SwitchButton, Search } from '@element-plus/icons-vue'
 
 export default {
@@ -102,6 +120,7 @@ export default {
     
     const activeIndex = ref('1')
     const searchKeyword = ref('')
+    const categories = ref([])
     
     const isAuthenticated = computed(() => authStore.isAuthenticated)
     const user = computed(() => authStore.user)
@@ -137,13 +156,25 @@ export default {
       }
     }
     
+    const fetchCategories = async () => {
+      try {
+        const response = await categoryAPI.getAllCategories()
+        categories.value = response.data
+      } catch (error) {
+        console.error('Failed to fetch categories:', error)
+        categories.value = []
+      }
+    }
+    
     onMounted(() => {
       authStore.initAuth()
+      fetchCategories()
     })
     
     return {
       activeIndex,
       searchKeyword,
+      categories,
       isAuthenticated,
       user,
       handleSelect,
@@ -224,5 +255,18 @@ export default {
 .el-menu--horizontal .el-menu-item a {
   color: inherit;
   text-decoration: none;
+}
+
+.el-menu--horizontal .el-sub-menu .el-sub-menu__title {
+  color: white;
+}
+
+.el-menu--horizontal .el-sub-menu .el-menu-item a {
+  color: #333;
+  text-decoration: none;
+}
+
+.el-menu--horizontal .el-sub-menu .el-menu-item a:hover {
+  color: #409eff;
 }
 </style> 

--- a/修复验证说明.md
+++ b/修复验证说明.md
@@ -1,0 +1,118 @@
+# 论坛系统个人资料问题修复说明
+
+## 已完成的修复
+
+### 1. 修复JWT过滤器配置
+
+**文件：** `backend/src/main/java/com/forum/config/JwtAuthenticationFilter.java`
+
+**修改内容：**
+- 在 `shouldNotFilter` 方法中添加了对 `/me` 接口的排除
+- 明确允许访问其他用户的公开信息（如 `/users/{username}` 和 `/users/{username}/stats`）
+- 确保所有包含 `/me` 的个人接口都需要JWT验证
+
+**修改前：**
+```java
+return path.startsWith("/api/auth/login") || 
+       path.startsWith("/api/auth/register") ||
+       (path.startsWith("/api/") && "GET".equals(request.getMethod()) && 
+        (path.contains("/posts") || path.contains("/categories") || 
+         path.contains("/comments") || path.contains("/users")));
+```
+
+**修改后：**
+```java
+return path.startsWith("/api/auth/login") || 
+       path.startsWith("/api/auth/register") ||
+       (path.startsWith("/api/") && "GET".equals(request.getMethod()) && 
+        (path.contains("/posts") || path.contains("/categories") || path.contains("/comments")) &&
+        !path.contains("/me")) || // 排除包含 /me 的个人接口
+       // 允许访问其他用户的公开信息（非 /me 接口）
+       (path.startsWith("/api/users/") && "GET".equals(request.getMethod()) && 
+        !path.contains("/me") && (path.matches(".*/users/[^/]+/?$") || path.matches(".*/users/[^/]+/stats$")));
+```
+
+### 2. 更新安全配置
+
+**文件：** `backend/src/main/java/com/forum/config/SecurityConfig.java`
+
+**修改内容：**
+- 更精确地配置了用户相关接口的访问权限
+- 明确区分了公开用户信息和个人信息接口
+- 添加了对 `/users/me/**` 接口的认证要求
+
+**修改前：**
+```java
+.requestMatchers(HttpMethod.GET, "/users/**").permitAll()
+```
+
+**修改后：**
+```java
+// 允许访问其他用户的公开信息，但不包括 /me 接口
+.requestMatchers(HttpMethod.GET, "/users/{username}", "/users/{username}/stats").permitAll()
+// 个人信息相关接口需要认证
+.requestMatchers("/users/me/**").authenticated()
+```
+
+## 修复原理
+
+### 问题根源
+原来的配置中，所有包含 `/users` 的GET请求都被跳过JWT验证，包括需要认证的个人接口如：
+- `/api/users/me/stats`
+- `/api/users/me/profile`
+
+### 修复方法
+1. **精确路径匹配：** 使用更精确的路径匹配规则，区分公开接口和个人接口
+2. **排除个人接口：** 明确排除所有包含 `/me` 的接口，确保它们需要JWT验证
+3. **安全配置同步：** 确保Spring Security配置与JWT过滤器配置一致
+
+## 验证步骤
+
+### 1. 启动应用
+```bash
+# 启动后端
+cd backend
+mvn spring-boot:run
+
+# 启动前端
+cd frontend
+npm install
+npm run dev
+```
+
+### 2. 测试场景
+
+#### 场景1：登录后访问个人资料
+1. 打开浏览器访问 `http://localhost:3000`
+2. 使用测试账号登录
+3. 点击右上角的用户头像下拉菜单
+4. 点击"个人资料"
+5. **预期结果：** 正常显示个人资料页面，不会跳转到登录页
+
+#### 场景2：访问其他用户的公开信息
+1. 在浏览器中直接访问 `http://localhost:8080/api/users/{username}`
+2. **预期结果：** 能够正常获取用户公开信息，无需认证
+
+#### 场景3：未登录访问个人接口
+1. 清除浏览器localStorage中的token
+2. 直接访问 `http://localhost:8080/api/users/me/stats`
+3. **预期结果：** 返回401未授权错误
+
+### 3. 日志验证
+启动应用后，查看控制台日志：
+- JWT过滤器应该正确处理 `/me` 接口的认证
+- 不应该出现"JWT token验证失败"的错误日志（除非token确实无效）
+
+## 注意事项
+
+1. **数据库准备：** 确保MySQL数据库已启动，并且配置正确
+2. **端口冲突：** 确保8080（后端）和3000（前端）端口没有被占用
+3. **依赖安装：** 前端需要先运行 `npm install` 安装依赖
+4. **CORS配置：** 如果前端运行在其他端口，需要更新CORS配置
+
+## 总结
+
+通过以上修复，解决了JWT过滤器配置过于宽泛导致的认证问题。现在：
+- 个人信息接口（包含 `/me`）需要正确的JWT认证
+- 公开用户信息接口仍然可以无需认证访问
+- 用户点击个人资料按钮后不会再被错误地跳转到登录页

--- a/导航栏分类问题修复说明.md
+++ b/导航栏分类问题修复说明.md
@@ -1,0 +1,174 @@
+# 导航栏分类问题修复说明
+
+## 问题描述
+顶部导航栏的分类选项显示不出来，用户无法在导航栏中看到分类列表。
+
+## 问题分析
+
+### 原始实现问题
+1. **静态菜单：** 原来的导航栏只有一个静态的"分类"链接，指向 `/categories` 页面
+2. **缺少动态数据：** 没有从后端获取分类数据并在导航栏中显示
+3. **用户体验不佳：** 用户需要点击进入分类页面才能看到所有分类
+
+### 期望的功能
+- 导航栏应该显示一个分类下拉菜单
+- 下拉菜单中应该包含所有主要分类
+- 用户可以直接从导航栏跳转到特定分类
+
+## 修复方案
+
+### 1. 修改导航栏结构
+**文件：** `frontend/src/components/Navbar.vue`
+
+**修改内容：**
+- 将静态的分类菜单项改为子菜单 (`el-sub-menu`)
+- 添加"所有分类"选项，保持原有功能
+- 动态渲染分类列表
+
+**修改前：**
+```vue
+<el-menu-item index="3">
+  <router-link to="/categories">分类</router-link>
+</el-menu-item>
+```
+
+**修改后：**
+```vue
+<el-sub-menu index="3">
+  <template #title>分类</template>
+  <el-menu-item index="3-0">
+    <router-link to="/categories">所有分类</router-link>
+  </el-menu-item>
+  <template v-if="categories.length > 0">
+    <el-menu-item 
+      v-for="category in categories.slice(0, 8)" 
+      :key="category.id" 
+      :index="`3-${category.id}`"
+    >
+      <router-link :to="`/categories/${category.id}`">
+        {{ category.name }}
+      </router-link>
+    </el-menu-item>
+  </template>
+  <el-menu-item v-else index="3-loading">
+    <span style="color: #999;">加载中...</span>
+  </el-menu-item>
+</el-sub-menu>
+```
+
+### 2. 添加分类数据获取
+**添加导入：**
+```javascript
+import { categoryAPI } from '@/api/categories'
+```
+
+**添加响应式数据：**
+```javascript
+const categories = ref([])
+```
+
+**添加数据获取方法：**
+```javascript
+const fetchCategories = async () => {
+  try {
+    const response = await categoryAPI.getAllCategories()
+    categories.value = response.data
+  } catch (error) {
+    console.error('Failed to fetch categories:', error)
+    categories.value = []
+  }
+}
+```
+
+**在组件挂载时获取数据：**
+```javascript
+onMounted(() => {
+  authStore.initAuth()
+  fetchCategories()
+})
+```
+
+### 3. 添加样式优化
+**添加子菜单样式：**
+```css
+.el-menu--horizontal .el-sub-menu .el-sub-menu__title {
+  color: white;
+}
+
+.el-menu--horizontal .el-sub-menu .el-menu-item a {
+  color: #333;
+  text-decoration: none;
+}
+
+.el-menu--horizontal .el-sub-menu .el-menu-item a:hover {
+  color: #409eff;
+}
+```
+
+## 功能特性
+
+### 1. 动态加载
+- 组件挂载时自动从后端获取分类数据
+- 支持异步加载，显示加载状态
+
+### 2. 限制显示数量
+- 最多显示8个分类，避免菜单过长
+- 使用 `categories.slice(0, 8)` 限制显示数量
+
+### 3. 错误处理
+- 网络请求失败时显示"加载中..."
+- 控制台输出错误信息便于调试
+
+### 4. 用户体验
+- 保留"所有分类"选项，用户可以查看完整分类列表
+- 直接链接到特定分类页面
+- 悬停效果和颜色变化
+
+## 验证步骤
+
+### 1. 启动应用
+```bash
+# 启动后端
+cd backend
+mvn spring-boot:run
+
+# 启动前端
+cd frontend
+npm install
+npm run dev
+```
+
+### 2. 测试分类菜单
+1. 打开浏览器访问 `http://localhost:3000`
+2. 查看顶部导航栏的"分类"菜单
+3. 点击"分类"应该显示下拉菜单
+4. 下拉菜单应该包含：
+   - "所有分类"选项
+   - 各个分类的链接（如：技术讨论、前端开发等）
+
+### 3. 功能测试
+1. 点击"所有分类"应该跳转到 `/categories` 页面
+2. 点击特定分类应该跳转到 `/categories/{id}` 页面
+3. 如果后端未启动，应该显示"加载中..."
+
+## 注意事项
+
+1. **数据库初始化：** 确保后端数据库中有分类数据
+2. **API访问权限：** 分类API是公开的，不需要认证
+3. **性能考虑：** 分类数据在组件挂载时获取，避免频繁请求
+4. **错误恢复：** 如果分类加载失败，用户仍可通过"所有分类"访问分类页面
+
+## 相关文件
+
+- `frontend/src/components/Navbar.vue` - 导航栏组件
+- `frontend/src/api/categories.js` - 分类API接口
+- `backend/src/main/java/com/forum/controller/CategoryController.java` - 分类控制器
+- `backend/src/main/java/com/forum/config/DataInitializer.java` - 数据初始化
+
+## 总结
+
+通过以上修复，导航栏现在能够：
+- 动态显示分类列表
+- 提供直接访问特定分类的快捷方式
+- 保持良好的用户体验和错误处理
+- 与现有的分类系统完美集成

--- a/论坛系统个人资料问题分析报告.md
+++ b/论坛系统个人资料问题分析报告.md
@@ -1,0 +1,154 @@
+# 论坛系统个人资料问题分析报告
+
+## 问题描述
+在前后端分离的论坛系统中，用户登录后点击个人资料按钮会清除token并跳转到登录页面。
+
+## 问题根本原因分析
+
+### 1. 主要问题：JWT过滤器配置问题
+
+**问题位置：** `backend/src/main/java/com/forum/config/JwtAuthenticationFilter.java`
+
+**核心问题：** 在JWT认证过滤器的 `shouldNotFilter` 方法中，存在一个严重的配置错误：
+
+```java
+@Override
+protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    String path = request.getRequestURI();
+    
+    // 对于这些路径不进行JWT验证
+    return path.startsWith("/api/auth/login") || 
+           path.startsWith("/api/auth/register") ||
+           (path.startsWith("/api/") && "GET".equals(request.getMethod()) && 
+            (path.contains("/posts") || path.contains("/categories") || 
+             path.contains("/comments") || path.contains("/users")));
+}
+```
+
+**问题分析：**
+- 该方法决定哪些请求不需要JWT验证
+- 对于所有以 `/api/` 开头的GET请求，如果路径包含 `/users`，就会跳过JWT验证
+- 但是 `/api/users/me/stats` 和 `/api/users/me/profile` 这些需要认证的用户个人接口也被误判为不需要验证的接口
+
+### 2. 具体执行流程分析
+
+当用户点击个人资料按钮时：
+
+1. **前端路由跳转：** 
+   - 用户点击"个人资料"按钮
+   - `Navbar.vue` 中的 `handleCommand` 方法执行 `router.push('/profile')`
+
+2. **路由守卫检查：**
+   - 路由守卫 (`frontend/src/router/index.js`) 检查 `/profile` 路由需要认证
+   - 检查 `authStore.isAuthenticated` 状态
+
+3. **Profile页面加载：**
+   - `Profile.vue` 组件的 `onMounted` 钩子调用 `fetchUserStats()`
+   - 该方法调用 `userAPI.getCurrentUserStats()`，发送GET请求到 `/api/users/me/stats`
+
+4. **后端JWT过滤器处理：**
+   - 由于路径包含 `/users` 且是GET请求，`shouldNotFilter` 返回true
+   - JWT过滤器跳过了token验证
+   - 请求直接到达 `UserController.getCurrentUserStats` 方法
+
+5. **控制器认证检查：**
+   ```java
+   @GetMapping("/me/stats")
+   public ResponseEntity<UserStatsDTO> getCurrentUserStats(Authentication authentication) {
+       if (authentication == null) {
+           return ResponseEntity.status(401).build();
+       }
+       // ...
+   }
+   ```
+   - 由于JWT过滤器跳过了验证，`Authentication` 对象为null
+   - 控制器返回401状态码
+
+6. **前端响应拦截器处理：**
+   ```javascript
+   // 响应拦截器
+   api.interceptors.response.use(
+     (response) => {
+       return response;
+     },
+     (error) => {
+       if (error.response?.status === 401) {
+         // 清除token并跳转到登录页
+         localStorage.removeItem("token");
+         localStorage.removeItem("user");
+         window.location.href = "/login";
+       }
+       return Promise.reject(error);
+     }
+   );
+   ```
+   - 响应拦截器检测到401状态码
+   - 自动清除localStorage中的token和用户信息
+   - 强制跳转到登录页面
+
+### 3. 其他相关问题
+
+1. **API路径不一致：**
+   - 后端控制器映射：`@RequestMapping("/users")`
+   - 但在 `SecurityConfig.java` 中，实际的API路径应该是 `/api/users/**`
+   - 这可能导致安全配置与实际路径不匹配
+
+2. **CORS配置：**
+   - 前端配置的CORS origin是 `http://localhost:3000`
+   - 但实际的前端可能运行在不同的端口
+
+## 解决方案
+
+### 1. 修复JWT过滤器配置（主要解决方案）
+
+修改 `JwtAuthenticationFilter.java` 中的 `shouldNotFilter` 方法：
+
+```java
+@Override
+protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    String path = request.getRequestURI();
+    
+    // 对于这些路径不进行JWT验证
+    return path.startsWith("/api/auth/login") || 
+           path.startsWith("/api/auth/register") ||
+           (path.startsWith("/api/") && "GET".equals(request.getMethod()) && 
+            (path.contains("/posts") || path.contains("/categories") || path.contains("/comments")) &&
+            !path.contains("/me")); // 排除包含 /me 的个人接口
+}
+```
+
+### 2. 更精确的路径配置
+
+更好的解决方案是明确指定不需要认证的路径：
+
+```java
+@Override
+protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    String path = request.getRequestURI();
+    
+    // 明确指定不需要JWT验证的路径
+    return path.startsWith("/api/auth/login") || 
+           path.startsWith("/api/auth/register") ||
+           path.matches("/api/posts(/\\d+)?") ||
+           path.matches("/api/categories(/\\d+)?") ||
+           path.matches("/api/comments(/\\d+)?") ||
+           path.matches("/api/users/[^/]+") || // 允许访问其他用户的公开信息
+           path.matches("/api/users/[^/]+/stats"); // 允许访问其他用户的统计信息
+}
+```
+
+### 3. 统一安全配置
+
+确保 `SecurityConfig.java` 中的路径配置与实际API路径一致。
+
+## 测试验证
+
+修复后，应该验证以下场景：
+1. 登录后点击个人资料按钮能正常显示个人信息
+2. 未登录用户无法访问个人资料页面
+3. 其他公开接口仍然可以正常访问
+4. 需要认证的接口能正确验证token
+
+## 总结
+
+这个问题的根本原因是JWT过滤器的路径配置过于宽泛，导致需要认证的个人接口被误判为公开接口。通过精确配置不需要认证的路径，可以解决这个问题。


### PR DESCRIPTION
Fixes token clearing on profile access and adds dynamic category display to the navigation bar.

The token clearing issue was caused by an overly broad `shouldNotFilter` rule in `JwtAuthenticationFilter.java`, which incorrectly bypassed JWT validation for authenticated `/api/users/me` endpoints. This led to a 401 response from the backend, triggering the frontend's token clear and redirect. Additionally, the navigation bar's category menu was static and did not dynamically fetch and display available categories.